### PR TITLE
[Blood Pressure]: Add timestamp to metadata

### DIFF
--- a/CareKitStore/CareKitStore/HealthKit/OCKHealthKitProxy.swift
+++ b/CareKitStore/CareKitStore/HealthKit/OCKHealthKitProxy.swift
@@ -206,7 +206,12 @@ extension HKCorrelation {
         let diastolicQuantity = diastolicSample.quantity
         let systolicValue = systolicQuantity.doubleValue(for: .millimeterOfMercury())
         let diastolicValue = diastolicQuantity.doubleValue(for: .millimeterOfMercury())
-        let metadata: [String: Any] = ["systolicValue": systolicValue, "diastolicValue": diastolicValue]
+
+        let metadata: [String: Any] = ["systolicValue": systolicValue,
+                                       "diastolicValue": diastolicValue,
+                                       "startDate": self.startDate.timeIntervalSince1970,
+                                       "endDate": self.endDate.timeIntervalSince1970
+        ]
         let sample = HKQuantitySample(type: quantityType, quantity: systolicQuantity, start: dateRange.start, end: dateRange.end, metadata: metadata)
         return sample
     }


### PR DESCRIPTION
We now add timeInterval into metadata for Correlation samples.
This way we can correctly pull the date time for blood-pressure samples